### PR TITLE
Add setuptools scm to build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 2e44a3b3cc7056a532c3a045e7e6e77cd57c7a2f7cdb41fbbf249882ac9825dd
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
@@ -19,6 +19,8 @@ requirements:
   host:
     - pip
     - python >=3.6
+    - setuptools >=45
+    - setuptools-scm >=6.2
   run:
     - numpy >=1.16.3
     - python >=3.6


### PR DESCRIPTION
Hi @jellis18 @AaronDJohnson @paulthebaker @vhaasteren I noticed that there's an inconsistency in the version information served via conda (I confirmed that this issue is not present with pip install) that I suspect is due to not having setuptools_scm installed on the host. I added this dependency to match https://github.com/nanograv/PTMCMCSampler/blob/master/pyproject.toml.

I'm not sure if there's a simple automated test for this.

```python
In [1]: import importlib.metadata

In [2]: importlib.metadata.version("ptmcmcsampler")
Out[2]: '0.0.0'

In [3]: import PTMCMCSampler
PTOptional mpi4py package is not installed.  MPI support is not available.
Optional acor package is not installed. Acor is optionally used to calculate the effective chain length for output in the chain file.

In [4]: PTMCMCSampler.__version__
Out[4]: '2.1.1'

In [5]: importlib.metadata.version("PTMCMCSampler")
Out[5]: '0.0.0'
```

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
